### PR TITLE
OAuth is disabled by default but can be overridden to enable in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,8 @@ services:
       - DB_DRIVER=com.mysql.jdbc.Driver
       - DB_DIALECT=org.hibernate.dialect.MySQLDialect
       - DB_URL=jdbc:mysql://db/elide?serverTimezone=UTC
-      - OAUTH_ENABLED=false
+      - OAUTH_ENABLED=${OAUTH_ENABLED:-false}
+      - JWKS_URL=${JWKS_URL}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
