### PR TITLE
Fix test errors after replacing cglib with ByteBuddy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,6 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
             <version>1.14.11</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.objenesis</groupId>

--- a/src/test/groovy/com/qubitpi/ws/jersey/template/application/DockerComposeITSpec.groovy
+++ b/src/test/groovy/com/qubitpi/ws/jersey/template/application/DockerComposeITSpec.groovy
@@ -15,16 +15,11 @@
  */
 package com.qubitpi.ws.jersey.template.application
 
-import org.hamcrest.Matchers
 import org.testcontainers.containers.DockerComposeContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.spock.Testcontainers
 
-import io.restassured.RestAssured
-import spock.lang.IgnoreIf
-
 @Testcontainers
-@IgnoreIf({System.getenv().get("MODEL_PACKAGE_NAME") == null})
 class DockerComposeITSpec extends AbstractITSpec {
 
     final DockerComposeContainer COMPOSE = new DockerComposeContainer(new File("docker-compose.yml"))


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed

- Fixed `java.lang.NoClassDefFoundError: net/bytebuddy/NamingStrategy$SuffixingRandom$BaseNameResolver` runtime error at Docker Compose startup

### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
