### PR TITLE
Bump Elide version to 7.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,11 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <version.elide>7.0.0-pr6</version.elide>
+        <version.elide>7.1.0</version.elide>
         <version.validation.api>3.0.1</version.validation.api>
         <version.jersey>3.1.1</version.jersey>
         <hibernate.version>6.2.4.Final</hibernate.version>
         <version.jcip.annotations>1.0</version.jcip.annotations>
-        <version.slf4j>2.0.7</version.slf4j>
-        <version.logback>1.4.7</version.logback>
         <version.owner>1.0.12</version.owner>
         <version.groovy>4.0.6</version.groovy>
         <version.jetty>11.0.15</version.jetty>
@@ -85,28 +83,6 @@
             <groupId>${model.package.jar.group.id}</groupId>
             <artifactId>${model.package.jar.artifact.id}</artifactId>
             <version>${model.package.jar.version}</version>
-        </dependency>
-
-        <!-- Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${version.slf4j}</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${version.logback}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.logstash.logback</groupId>
-            <artifactId>logstash-logback-encoder</artifactId>
-            <version>4.11</version>
-        </dependency>
-        <dependency>
-            <groupId>io.sentry</groupId>
-            <artifactId>sentry-logback</artifactId>
-            <version>6.25.2</version>
         </dependency>
 
         <!-- Elide -->
@@ -181,6 +157,13 @@
             <groupId>org.aeonbits.owner</groupId>
             <artifactId>owner</artifactId>
             <version>${version.owner}</version>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.1.1</version>
         </dependency>
 
         <!-- Testing -->

--- a/settings.xml.example
+++ b/settings.xml.example
@@ -9,7 +9,7 @@
             <properties>
                 <model.package.jar.group.id>io.github.qubitpi</model.package.jar.group.id>
                 <model.package.jar.artifact.id>jersey-webservice-template-jpa-data-models</model.package.jar.artifact.id>
-                <model.package.jar.version>1.0.1</model.package.jar.version>
+                <model.package.jar.version>1.0.13</model.package.jar.version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

- Changed the Elide version to the latest
- Explicitly bind `GraphQLSettings` and `JsonApiSettingsBuilder` to prevent runtime NPE like `java.lang.NullPointerException: Cannot invoke "com.yahoo.elide.graphql.GraphQLSettings.getFederation()" because "graphQLSettings" is null`

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation
